### PR TITLE
Added support for non authenticated logins

### DIFF
--- a/Coinfloor.js
+++ b/Coinfloor.js
@@ -24,9 +24,16 @@
 			 */
 			_event_handlers["Welcome"] =  function(msg){
 				console.log("Authenticating");
-				authenticate(user_id, password, api_key, msg.nonce, function(){
+				if(user_id)
+				{
+
+					authenticate(user_id, password, api_key, msg.nonce, function(){
+						onConnect();
+					});
+				}
+				else {
 					onConnect();
-				});
+				}
 			};
 
 			/*


### PR DESCRIPTION
Code checks to see if the userid is set before attempting a login request.

Not all coinfloor api calls require a login. Therefore it seemed useful to provide a way of allowing a non authenticated user access to the api.

If you want to build this feature into a future release that would be great - happy to  make any changes or discuss further too.